### PR TITLE
allow privmsg notifications via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Usage
 
     /SET notifier_channel_regex (mychannel1|mychannel2)
 
- by default we don't send notifications for privmsgs you can able this by setting this flag to 1
+ by default we don't send notifications for privmsgs you can enable this by setting this flag to 1
 
     /SET notifier_on_privmsg 1 
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Configuration
 ---
     /SET notifier_on_regex [regex]
     /SET notifier_channel_regex [regex]
+    /SET notifier_on_privmsg <0|1>
 
 Usage
 ---
@@ -34,6 +35,10 @@ Usage
  only notifier things for mychannel1 and mychannel2
 
     /SET notifier_channel_regex (mychannel1|mychannel2)
+
+ by default we don't send notifications for privmsgs you can able this by setting this flag to 1
+
+    /SET notifier_on_privmsg 1 
 
 Didn't irssi-growl let me choose an icon?
 ---

--- a/notifier.pl
+++ b/notifier.pl
@@ -118,7 +118,10 @@ sub notifier_privmsg {
   # $host = host of the nick who sent the message
   my ($server, $data, $nick, $host) = @_;
     my ($target, $text) = split(/ :/, $data, 2);
-    # notifier_it($server, $nick, $data, $target, $nick); # actually, don't do this.
+    # only notify if we're permitting notification on privmsg
+    if (Irssi::settings_get_str('notifier_on_privmsg') == 1) {
+        notifier_it($server, $nick, $data, $target, $nick); 
+    }
   Irssi::signal_continue($server, $data, $nick, $host);
 }
 
@@ -126,6 +129,7 @@ sub notifier_privmsg {
 Irssi::settings_add_str('misc', 'notifier_on_regex', 0);      # false
 Irssi::settings_add_str('misc', 'notifier_channel_regex', 0); # false
 Irssi::settings_add_str('misc', 'notifier_on_nick', 1);       # true
+Irssi::settings_add_str('misc', 'notifier_on_privmsg', 0);    # false
 Irssi::signal_add('message public', 'notifier_message');
 Irssi::signal_add('message private', 'notifier_message');
 Irssi::signal_add('message own_public', 'notifier_message');


### PR DESCRIPTION
In the original code notifications for privmsg was commented out. Completely understand why this may be a bad thing for some folks.

This patch basically adds a new config flag `notifier_on_privmsg` by default it is off to preserve the original behaviour. Setting this to `1` enables notification of privmsg's.
