### PR TITLE
Added Voice Notifications and Explicit Filter for Identify Command

### DIFF
--- a/notifier.pl
+++ b/notifier.pl
@@ -51,7 +51,9 @@ sub do_notifier {
   my ($server, $title, $data) = @_;
     $data =~ s/["';]//g;
     system("terminal-notifier -message '$data' -title '$title' >> /dev/null 2>&1");
-    system("say -v Vicki '$data'");
+    if (Irssi::settings_get_str('notifier_voice') == 1) {
+      system("say -v Vicki '$data'");
+    }
     return 1
 }
 

--- a/notifier.pl
+++ b/notifier.pl
@@ -129,6 +129,7 @@ sub notifier_privmsg {
 }
 
 # Hook me up
+Irssi::settings_add_str('misc', 'notifier_voice', 0);      # false
 Irssi::settings_add_str('misc', 'notifier_on_regex', 0);      # false
 Irssi::settings_add_str('misc', 'notifier_channel_regex', 0); # false
 Irssi::settings_add_str('misc', 'notifier_on_nick', 1);       # true

--- a/notifier.pl
+++ b/notifier.pl
@@ -69,6 +69,9 @@ sub notifier_it {
     if($channel_filter && $server->ischannel($channel)) {
       return 0 if $channel !~ /$channel_filter/;
     }
+    if(index($data, 'identify') != -1) {
+      return 0;
+    }
 
     $title = $title . " " . $channel;
     do_notifier($server, $title, $data);

--- a/notifier.pl
+++ b/notifier.pl
@@ -51,6 +51,7 @@ sub do_notifier {
   my ($server, $title, $data) = @_;
     $data =~ s/["';]//g;
     system("terminal-notifier -message '$data' -title '$title' >> /dev/null 2>&1");
+    system("say -v Vicki '$data'");
     return 1
 }
 


### PR DESCRIPTION
Hey Paddy

Great little plugin. Feel free not to merge this because it's a whole lot of silly. But I thought I'd send a pull request that you can leave in your issues tab (if you want) for people to see this because while it's silly, it's also kinda neat. If you don't want to pull it, then people can fork it off me.

I was having issues with not getting notification sounds and would miss every mention of my nick. So I added "say" to the notifier_it function so now Victoria (my favorite little say voice) reads me messages so I don't miss them. I also noticed that the channel regex didn't seem to work (maybe it just doesn't load in time) for my autosendcmd for identify. I didn't want it notifying my password and very much didn't want Victoria speaking my password, so I put an explicit check for it and return 0 if it is.

I don't really know perl, but I had fun on this. Thanks for giving me a place to start!

Kyle
